### PR TITLE
Asyncpg support (#1)

### DIFF
--- a/sanic_cookies/__init__.py
+++ b/sanic_cookies/__init__.py
@@ -1,5 +1,6 @@
 from .interfaces import (
     InMemory,
+    AsyncPG,
     Aioredis,
     InCookieEnc
 )

--- a/sanic_cookies/interfaces/__init__.py
+++ b/sanic_cookies/interfaces/__init__.py
@@ -1,5 +1,6 @@
+from .asyncpg import AsyncPG
 from .aioredis import Aioredis
 from .inmemory import InMemory
 from .incookie import InCookieEnc
 
-STATIC_SID_COOKIE_INTERFACES = [Aioredis, InMemory]  # https://bit.ly/1UZD8Q1 (OWASP Privelage Escalation Recommendations)
+STATIC_SID_COOKIE_INTERFACES = [AsyncPG, Aioredis, InMemory]  # https://bit.ly/1UZD8Q1 (OWASP Privelage Escalation Recommendations)

--- a/sanic_cookies/interfaces/asyncpg.py
+++ b/sanic_cookies/interfaces/asyncpg.py
@@ -1,0 +1,67 @@
+import datetime
+import ujson
+import uuid
+
+
+"""
+# Create table statement (run once before ever calling this code)
+TODO: move to SQLalchemy?
+
+CREATE TABLE IF NOT EXISTS sessions
+(
+    created_at timestamp without time zone NOT NULL,
+    expires_at timestamp without time zone,
+    sid character varying,
+    val character varying,
+    CONSTRAINT sessions_pkey PRIMARY KEY (sid)
+);
+"""
+
+
+class AsyncPG:  # pragma: no cover
+    '''
+        encoder & decoder:
+
+            e.g. json, ujson, pickle, cpickle, bson, msgpack etc..
+            Default ujson
+
+        Requires postgres 9.5+ for UPSERT (ON CONFLICT DO UPDATE)
+    '''
+    def __init__(
+        self,
+        client,
+        prefix='session:',
+        encoder=ujson.dumps,
+        decoder=ujson.loads,
+        sid_factory=lambda: uuid.uuid4().hex
+    ):
+        self.client = client
+        self.prefix = prefix
+        self.encoder = encoder
+        self.decoder = decoder
+        self.sid_factory = sid_factory
+
+    async def fetch(self, sid, **kwargs):
+        val = await self.client.scalar(
+            "SELECT val FROM sessions WHERE sid = $1 AND expires_at > NOW()",
+            sid,
+        )
+        if val is not None:
+            return self.decoder(val)
+
+    async def store(self, sid, expiry, val, **kwargs):
+        if val is not None:
+            val = self.encoder(val)
+            await self.client.scalar(
+                # Upsert using postgres 9.5+
+                'INSERT INTO sessions(created_at, sid, val, expires_at) VALUES(NOW(), $1, $2, $3) ON CONFLICT (sid) DO UPDATE SET val = EXCLUDED.val, expires_at = EXCLUDED.expires_at',  # noqa
+                sid,
+                val,
+                datetime.datetime.utcnow() + datetime.timedelta(seconds=expiry)
+            )
+
+    async def delete(self, sid, **kwargs):
+        await self.client.scalar(
+            "DELETE FROM sessions WHERE sid = $1",
+            sid,
+        )


### PR DESCRIPTION
I'm not sure you'd want to merge this, but I'm working on a project that uses [Gino](https://github.com/fantix/gino/blob/master/docs/sanic.rst) and I put this together and it's working for me.

Code needed to run it:
```
from sanic import Sanic
from gino.ext.sanic import Gino

from something_secure import DB_SETTINGS

app = Sanic()
app.config.update(DB_SETTINGS)
db = Gino() 
db.init_app(app)

interface = AsyncPG(client=db)
auth_session = AuthSession(app, master_interface=interface)

# define routes here

if __name__ == '__main__':
    app.run(host='127.0.0.1', port='8080')
```

I think the pure `asyncpg` module uses a different function call (not `scalar()`) to execute a SQL query but I haven't tried it, so this may be more for reference to others vs actually merging it in.